### PR TITLE
fixed deprecated delete_token, now called owner_token

### DIFF
--- a/scripts/send-cli
+++ b/scripts/send-cli
@@ -51,9 +51,9 @@ def case_file(file, fileName=None):
     print("Would you like to set a download password? if so enter it now (push enter for no password)")
     password = getpass.getpass()
     if password != '':
-        secretUrl, delete_token = sendclient.upload.send_file(service, file, password=password, ignoreVersion=args.ignore_version, fileName=fileName)
+        secretUrl, fileId, delete_token = sendclient.upload.send_file(service, file, password=password, ignoreVersion=args.ignore_version, fileName=fileName)
     else:
-        secretUrl, delete_token = sendclient.upload.send_file(service, file, ignoreVersion=args.ignore_version, fileName=fileName)
+        secretUrl, fileId, delete_token = sendclient.upload.send_file(service, file, ignoreVersion=args.ignore_version, fileName=fileName)
 
     print('File Uploaded, use the following link to retrieve it')
     print(secretUrl)

--- a/sendclient/delete.py
+++ b/sendclient/delete.py
@@ -3,7 +3,7 @@ import requests
 def api_delete(service, file_id, owner_token):
     """Delete a file already uploaded to Send"""
     service += 'api/delete/%s' % file_id
-    r = requests.post(service, json={'owner_token': owner_token})
+    r = requests.post(service, json={'owner_token': owner_token, 'delete_token': owner_token})
     r.raise_for_status()
 
     if r.text == 'OK':

--- a/sendclient/delete.py
+++ b/sendclient/delete.py
@@ -1,9 +1,9 @@
 import requests
 
-def api_delete(service, file_id, delete_token):
+def api_delete(service, file_id, owner_token):
     """Delete a file already uploaded to Send"""
     service += 'api/delete/%s' % file_id
-    r = requests.post(service, json={'delete_token': delete_token})
+    r = requests.post(service, json={'owner_token': owner_token})
     r.raise_for_status()
 
     if r.text == 'OK':

--- a/sendclient/upload.py
+++ b/sendclient/upload.py
@@ -65,8 +65,8 @@ def api_upload(service, encData, encMeta, keys):
     secretUrl = body_json['url'] + '#' + unpadded_urlsafe_b64encode(keys.secretKey)
     fileId = body_json['id']
     fileNonce = unpadded_urlsafe_b64decode(r.headers['WWW-Authenticate'].replace('send-v1 ', ''))
-    delete_token = body_json['delete']
-    return secretUrl, fileId, fileNonce, delete_token
+    owner_token = body_json['owner']
+    return secretUrl, fileId, fileNonce, owner_token
 
 def sign_nonce(key, nonce):
     ''' sign the server nonce from the WWW-Authenticate header with an authKey'''
@@ -98,10 +98,10 @@ def send_file(service, file, fileName=None, password=None, ignoreVersion=False):
     encMeta = encrypt_metadata(keys, fileName)
 
     print('Uploading "' + fileName + '"')
-    secretUrl, fileId, fileNonce, delete_token = api_upload(service, encData, encMeta, keys)
+    secretUrl, fileId, fileNonce, owner_token = api_upload(service, encData, encMeta, keys)
 
     if password != None:
         print('Setting password')
         set_password(service, keys, secretUrl, fileId, password, fileNonce)
 
-    return secretUrl, delete_token
+    return secretUrl, owner_token

--- a/sendclient/upload.py
+++ b/sendclient/upload.py
@@ -65,7 +65,10 @@ def api_upload(service, encData, encMeta, keys):
     secretUrl = body_json['url'] + '#' + unpadded_urlsafe_b64encode(keys.secretKey)
     fileId = body_json['id']
     fileNonce = unpadded_urlsafe_b64decode(r.headers['WWW-Authenticate'].replace('send-v1 ', ''))
-    owner_token = body_json['owner']
+    try:
+        owner_token = body_json['owner']
+    except:
+        owner_token = body_json['delete']
     return secretUrl, fileId, fileNonce, owner_token
 
 def sign_nonce(key, nonce):
@@ -104,4 +107,4 @@ def send_file(service, file, fileName=None, password=None, ignoreVersion=False):
         print('Setting password')
         set_password(service, keys, secretUrl, fileId, password, fileNonce)
 
-    return secretUrl, owner_token
+    return secretUrl, fileId, owner_token


### PR DESCRIPTION
According to official [FF Send repo](https://github.com/mozilla/send/blob/master/server/routes/upload.js) delete param is deprecated and must be replaced  by owner. This breaks the uploading of files to the production server as its response does not contain such key.

I simply changed the name of this key  in update.py and rename the variables to maintain the coherence. In delete.py modified the request payload to owner_token as it has also been changed.